### PR TITLE
Add React/Tailwind quartett generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,20 @@ Privacy
 All data remains on your device. No backend, no tracking, no cloud—your creations are yours only.
 
 Build and play your own Quartet game — completely offline and privacy-friendly!
+
+## Development
+
+1. Install dependencies (Node >=18 required):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+
+The app works completely offline and stores data in your browser's LocalStorage.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "quartett-generator",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1",
+    "jszip": "^3.10.1",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.24",
+    "tailwindcss": "^3.3.3",
+    "vite": "^4.3.9"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Quartett Generator</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,130 @@
+import { useState, useEffect } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+import jsPDF from 'jspdf'
+import html2canvas from 'html2canvas'
+import JSZip from 'jszip'
+import CardEditor from './components/CardEditor'
+import CardBackEditor from './components/CardBackEditor'
+import Preview from './components/Preview'
+
+const STORAGE_KEY = 'quartett-generator'
+
+export default function App() {
+  const [title, setTitle] = useState('')
+  const [categories, setCategories] = useState(['Wert 1', 'Wert 2'])
+  const [cards, setCards] = useState([])
+  const [back, setBack] = useState({ type: 'color', color: '#ffffff', text: 'Mein Quartett', image: null })
+
+  // Load from storage
+  useEffect(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      const data = JSON.parse(saved)
+      setTitle(data.title || '')
+      setCategories(data.categories || ['Wert 1', 'Wert 2'])
+      setCards(data.cards || [])
+      setBack(data.back || { type: 'color', color: '#ffffff', text: 'Mein Quartett', image: null })
+    }
+  }, [])
+
+  // Save to storage
+  useEffect(() => {
+    const data = { title, categories, cards, back }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  }, [title, categories, cards, back])
+
+  const addCategory = () => setCategories([...categories, `Wert ${categories.length + 1}`])
+  const updateCategory = (i, value) => {
+    const newCats = [...categories]
+    newCats[i] = value
+    setCategories(newCats)
+  }
+  const removeCategory = (i) => {
+    const newCats = categories.filter((_, idx) => idx !== i)
+    setCategories(newCats)
+    setCards(cards.map(c => {
+      const vals = { ...c.values }
+      delete vals[i]
+      return { ...c, values: vals }
+    }))
+  }
+
+  const addCard = () => {
+    const emptyValues = {}
+    categories.forEach((_, i) => (emptyValues[i] = ''))
+    setCards([...cards, { id: uuidv4(), title: '', image: null, values: emptyValues }])
+  }
+
+  const updateCard = (id, card) => {
+    setCards(cards.map(c => (c.id === id ? card : c)))
+  }
+
+  const removeCard = (id) => {
+    setCards(cards.filter(c => c.id !== id))
+  }
+
+  const exportPDF = async () => {
+    const doc = new jsPDF({ unit: 'pt', format: [300, 400] })
+    for (let i = 0; i < cards.length; i++) {
+      const front = await html2canvas(document.getElementById(`card-front-${cards[i].id}`))
+      const backCanvas = await html2canvas(document.getElementById('card-back-preview'))
+      if (i > 0) doc.addPage()
+      doc.addImage(front.toDataURL('image/jpeg'), 'JPEG', 0, 0, 300, 400)
+      doc.addPage()
+      doc.addImage(backCanvas.toDataURL('image/jpeg'), 'JPEG', 0, 0, 300, 400)
+    }
+    doc.save('quartett.pdf')
+  }
+
+  const exportZIP = async () => {
+    const zip = new JSZip()
+    for (let card of cards) {
+      const front = await html2canvas(document.getElementById(`card-front-${card.id}`))
+      zip.file(`front-${card.title || card.id}.jpg`, front.toDataURL('image/jpeg').split(',')[1], { base64: true })
+    }
+    const backCanvas = await html2canvas(document.getElementById('card-back-preview'))
+    zip.file('back.jpg', backCanvas.toDataURL('image/jpeg').split(',')[1], { base64: true })
+    const blob = await zip.generateAsync({ type: 'blob' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'quartett.zip'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="container mx-auto p-4 space-y-4">
+      <h1 className="text-2xl font-bold text-center">Quartett Generator</h1>
+      <div className="space-y-2">
+        <label className="block">
+          <span className="font-semibold">Spieltitel:</span>
+          <input className="border rounded w-full p-2" value={title} onChange={e => setTitle(e.target.value)} />
+        </label>
+        <div>
+          <h2 className="font-semibold mb-2">Kategorien</h2>
+          {categories.map((cat, i) => (
+            <div key={i} className="flex items-center mb-1">
+              <input className="border rounded p-1 flex-1" value={cat} onChange={e => updateCategory(i, e.target.value)} />
+              <button className="ml-2 text-red-500" onClick={() => removeCategory(i)}>X</button>
+            </div>
+          ))}
+          <button className="mt-2 bg-blue-500 text-white px-2 py-1 rounded" onClick={addCategory}>Kategorie hinzufügen</button>
+        </div>
+        <div>
+          <h2 className="font-semibold mb-2">Karten</h2>
+          {cards.map(card => (
+            <CardEditor key={card.id} card={card} categories={categories} onChange={c => updateCard(card.id, c)} onRemove={() => removeCard(card.id)} />
+          ))}
+          <button className="mt-2 bg-blue-500 text-white px-2 py-1 rounded" onClick={addCard}>Karte hinzufügen</button>
+        </div>
+        <CardBackEditor back={back} setBack={setBack} />
+        <div className="flex space-x-2">
+          <button className="bg-green-500 text-white px-4 py-2 rounded" onClick={exportPDF}>Export PDF</button>
+          <button className="bg-green-500 text-white px-4 py-2 rounded" onClick={exportZIP}>Export ZIP</button>
+        </div>
+        <Preview title={title} categories={categories} cards={cards} back={back} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/CardBackEditor.jsx
+++ b/src/components/CardBackEditor.jsx
@@ -1,0 +1,32 @@
+export default function CardBackEditor({ back, setBack }) {
+  const handleImage = e => {
+    const file = e.target.files[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => setBack({ ...back, type: 'image', image: reader.result })
+      reader.readAsDataURL(file)
+    }
+  }
+
+  return (
+    <div>
+      <h2 className="font-semibold mb-2">Rückseite</h2>
+      <div className="mb-2">
+        <label className="mr-2"><input type="radio" checked={back.type === 'color'} onChange={() => setBack({ ...back, type: 'color', image: null })} /> Farbe</label>
+        <label className="mr-2"><input type="radio" checked={back.type === 'image'} onChange={() => setBack({ ...back, type: 'image' })} /> Bild</label>
+      </div>
+      {back.type === 'color' && (
+        <div className="space-y-2">
+          <input type="color" value={back.color} onChange={e => setBack({ ...back, color: e.target.value })} />
+          <input className="border p-1" value={back.text} onChange={e => setBack({ ...back, text: e.target.value })} placeholder="Text" />
+        </div>
+      )}
+      {back.type === 'image' && (
+        <div>
+          {back.image && <img src={back.image} alt="" className="h-24 mb-2" />}
+          <input type="file" onChange={handleImage} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/CardEditor.jsx
+++ b/src/components/CardEditor.jsx
@@ -1,0 +1,44 @@
+import { useRef } from 'react'
+
+export default function CardEditor({ card, categories, onChange, onRemove }) {
+  const fileRef = useRef(null)
+
+  const update = (field, value) => {
+    onChange({ ...card, [field]: value })
+  }
+
+  const updateValue = (idx, value) => {
+    const vals = { ...card.values, [idx]: value }
+    onChange({ ...card, values: vals })
+  }
+
+  const handleImage = e => {
+    const file = e.target.files[0]
+    if (file) {
+      const reader = new FileReader()
+      reader.onload = () => update('image', reader.result)
+      reader.readAsDataURL(file)
+    }
+  }
+
+  return (
+    <div className="border p-2 mb-2">
+      <div className="flex justify-between items-center">
+        <input className="border p-1 flex-1" value={card.title} onChange={e => update('title', e.target.value)} placeholder="Kartentitel" />
+        <button className="ml-2 text-red-500" onClick={onRemove}>X</button>
+      </div>
+      <div className="mt-2">
+        {categories.map((cat, i) => (
+          <div key={i} className="flex items-center mb-1">
+            <span className="w-24 mr-2 text-sm">{cat}</span>
+            <input className="border p-1 flex-1" value={card.values[i] || ''} onChange={e => updateValue(i, e.target.value)} />
+          </div>
+        ))}
+      </div>
+      <div className="mt-2">
+        {card.image && <img src={card.image} alt="" className="h-24 mb-2" />}
+        <input type="file" ref={fileRef} onChange={handleImage} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -1,0 +1,31 @@
+export default function Preview({ title, categories, cards, back }) {
+  return (
+    <div>
+      <h2 className="font-semibold mb-2">Vorschau</h2>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {cards.map(card => (
+          <div key={card.id} id={`card-front-${card.id}`} className="border bg-white p-2 aspect-[3/4] flex flex-col">
+            <h3 className="font-semibold text-center mb-2">{card.title}</h3>
+            {card.image && <img src={card.image} alt="" className="h-24 object-cover mb-2" />}
+            <div className="text-sm flex-1">
+              {categories.map((cat, i) => (
+                <div key={i} className="flex justify-between">
+                  <span>{cat}</span>
+                  <span>{card.values[i]}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+        <div id="card-back-preview" className="border bg-white p-2 aspect-[3/4] flex items-center justify-center">
+          {back.type === 'image' && back.image && <img src={back.image} alt="" className="object-cover w-full h-full" />}
+          {back.type === 'color' && (
+            <div style={{ background: back.color }} className="w-full h-full flex items-center justify-center">
+              <span className="text-lg font-bold text-white">{back.text}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  base: './',
+})


### PR DESCRIPTION
## Summary
- initialize React + Tailwind project (Vite style)
- implement card game editor with local storage
- allow editing categories, cards and card back
- export cards to PDF or ZIP via jsPDF/html2canvas and JSZip
- add usage instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f8e18398c832184fff9bc4d24ab80