### PR TITLE
Add deploy-main to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
         cache: 'npm'
     - run: npm install
     - run: npm test -- --watchAll=false
-    - run: npm run build
+    - run: npm run deploy-main
       env:
         CI: true

--- a/README.md
+++ b/README.md
@@ -19,10 +19,17 @@ Quartet Card Game Generator is an offline-first web app for designing your own q
    This opens the app at `http://localhost:3000`.
 2. Edit the game title, add categories and cards, and upload images. All changes are saved in your browser's local storage.
 3. When finished, choose **Export PDF** to get a printable PDF or **Export ZIP** for high quality JPEGs of every card front and back.
-4. Update `package.json`'s `homepage` with your GitHub username, then run:
-   ```bash
-   npm run deploy
-   ```
+4. Update `package.json`'s `homepage` with your GitHub username. To publish the
+   app on GitHub Pages you can use either approach:
+   - **gh-pages branch**
+     ```bash
+     npm run deploy
+     ```
+   - **`/docs` folder on `main`**
+     ```bash
+     npm run deploy-main
+     ```
+     Set GitHub Pages to use the `docs` folder on the `main` branch.
    Then open `https://<your-gh-username>.github.io/Quartett_Generator`.
 
 Clearing your browser storage resets the app to its defaults.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,19 @@
     "test": "react-scripts test --env=jsdom",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build",
+    "deploy-main": "npm run build && rm -rf docs && cp -r build docs",
     "eject": "react-scripts eject"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- run `npm run deploy-main` in the GitHub Actions workflow
- ensure the README shows how to publish from the `/docs` folder

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687fa020346c832195579b0bb54a0c4f